### PR TITLE
add EventTarget event handlers to node window

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "min-document": "^2.6.1",
-    "process": "~0.5.1"
+    "process": "~0.5.1",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "tape": "^2.12.0"

--- a/window.js
+++ b/window.js
@@ -1,7 +1,16 @@
+var extend = require('xtend/mutable')
+
+var minWindow = {
+    removeEventListener: require('min-document/event/remove-event-listener'),
+    addEventListener: require('min-document/event/add-event-listener'),
+    dispatchEvent: require('min-document/event/dispatch-event'),
+}
+
+
 if (typeof window !== "undefined") {
     module.exports = window;
 } else if (typeof global !== "undefined") {
-    module.exports = global;
+    module.exports = extend(global, minWindow)
 } else {
-    module.exports = {};
+    module.exports = minWindow
 }


### PR DESCRIPTION
the use case is to be able to run [mercury component](https://github.com/ahdinosaur/grid-ui) [tests](https://github.com/ahdinosaur/grid-ui/blob/master/test/index.js) in node that involve [window event handlers](https://github.com/ahdinosaur/grid-ui/blob/065bcb5b688b1cf5f099a91b7f649c0e37a43390/lib/edgeEvent.js#L74-L79).

i'm not sure if this commit is necessarily the best way to do this, seems hacky. i was thinking maybe we can define a more proper window in min-document, but then again maybe each of these DOM interfaces ([EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget), [document](https://developer.mozilla.org/en-US/docs/Web/API/document), [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element), [window](https://developer.mozilla.org/en-US/docs/Web/API/window), ...) should be separate modules, or i don't know.

cheers!
