### PR TITLE
Support the web worker context in window.js

### DIFF
--- a/window.js
+++ b/window.js
@@ -2,6 +2,8 @@ if (typeof window !== "undefined") {
     module.exports = window;
 } else if (typeof global !== "undefined") {
     module.exports = global;
+} else if (typeof self !== "undefined"){
+    module.exports = self;
 } else {
     module.exports = {};
 }


### PR DESCRIPTION
I noticed an issue when in the Web Worker context that we write window to an empty object. I believe that `self` is the correct global object for the Worker context, https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope. But I am not 100 % sure. 

Please me know if you think this an reasonable fix. 

Note that I found this issue because `xhr` is currently broken in web workers, but I don't see any reason why it can't work. 

Thanks. 
