### PR TITLE
Update `process` from v0.5.x to v0.11.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "min-document": "^2.19.0",
-    "process": "~0.5.1"
+    "process": "^0.11.10"
   },
   "devDependencies": {
     "tape": "^2.12.0"


### PR DESCRIPTION
npm CLI >= v3.0.0 tries to dedupe the dependencies by default, and keeping dependencies up-to-date helps better deduplication.
