### PR TITLE
Issue with ES6 module bundler Rollup

### DIFF
--- a/document.js
+++ b/document.js
@@ -2,8 +2,8 @@ var topLevel = typeof global !== 'undefined' ? global :
     typeof window !== 'undefined' ? window : {}
 var minDoc = require('min-document');
 
-if (typeof document !== 'undefined') {
-    module.exports = document;
+if (typeof topLevel.document !== 'undefined') {
+    module.exports = topLevel.document;
 } else {
     var doccy = topLevel['__GLOBAL_DOCUMENT_CACHE@4'];
 


### PR DESCRIPTION
When converting commonJS modules to ES6 modules using Rollup, the name of generated bundle and document instance is clashing. To avoid that I name spaced use of document instance.

I am using following with Rollup:
* var commonjs = require('rollup-plugin-commonjs');
* var replace = require('rollup-plugin-replace');