### PR TITLE
Moving module.exports to the top level

### DIFF
--- a/document.js
+++ b/document.js
@@ -3,13 +3,13 @@ var topLevel = typeof global !== 'undefined' ? global :
 var minDoc = require('min-document');
 
 if (typeof document !== 'undefined') {
-    module.exports = document;
+    var doccy = document;
 } else {
     var doccy = topLevel['__GLOBAL_DOCUMENT_CACHE@4'];
 
     if (!doccy) {
         doccy = topLevel['__GLOBAL_DOCUMENT_CACHE@4'] = minDoc;
     }
-
-    module.exports = doccy;
 }
+
+module.exports = doccy;

--- a/document.js
+++ b/document.js
@@ -2,10 +2,12 @@ var topLevel = typeof global !== 'undefined' ? global :
     typeof window !== 'undefined' ? window : {}
 var minDoc = require('min-document');
 
+var doccy;
+
 if (typeof document !== 'undefined') {
-    var doccy = document;
+    doccy = document;
 } else {
-    var doccy = topLevel['__GLOBAL_DOCUMENT_CACHE@4'];
+    doccy = topLevel['__GLOBAL_DOCUMENT_CACHE@4'];
 
     if (!doccy) {
         doccy = topLevel['__GLOBAL_DOCUMENT_CACHE@4'] = minDoc;

--- a/window.js
+++ b/window.js
@@ -1,9 +1,11 @@
 if (typeof window !== "undefined") {
-    module.exports = window;
+    var win = window;
 } else if (typeof global !== "undefined") {
-    module.exports = global;
+    var win = global;
 } else if (typeof self !== "undefined"){
-    module.exports = self;
+    var win = self;
 } else {
-    module.exports = {};
+    var win = {};
 }
+
+module.exports = win;

--- a/window.js
+++ b/window.js
@@ -1,11 +1,13 @@
+var win;
+
 if (typeof window !== "undefined") {
-    var win = window;
+    win = window;
 } else if (typeof global !== "undefined") {
-    var win = global;
+    win = global;
 } else if (typeof self !== "undefined"){
-    var win = self;
+    win = self;
 } else {
-    var win = {};
+    win = {};
 }
 
 module.exports = win;


### PR DESCRIPTION
I am using a Rollup plugin which converts CommonJS to ES6 modules.

It does this by converting `module.exports = foo;` into `export default foo;`

However, this only works if the `module.exports` is at the top level, because ES6 requires all exports to be at the top level.

This pull request moves the `module.exports` to the top level, so that it will work with my plugin.